### PR TITLE
修复搜索结果分数不显示

### DIFF
--- a/lib/content.js
+++ b/lib/content.js
@@ -66,7 +66,7 @@ function init() {
     console.log("当前所在url:" + url);
     if (url.includes("problemset/all")) {
         update();  // 更新
-        var observer = new MutationObserver(update);
+        var observer = new MutationObserver(debounce(update, 500)); // 延迟半秒更新
         var config = {
             attributes: true,
             characterData: true,
@@ -78,10 +78,7 @@ function init() {
         // 监听第一行
         observer.observe($("*[role=rowgroup] *[role=row] div")[1], config); 
         // 监听头
-        const tagButtonId = localization === 'en'
-            ? "#headlessui-popover-button-19" 
-            : "#headlessui-popover-button-18";
-        var head = $(tagButtonId).parent().parent();
+        var head = $("div.mb-3.flex.flex-col > div.flex.justify-between")
         if (head != undefined)  {
             observer.observe(head[0], config);
         }
@@ -91,5 +88,13 @@ function init() {
 
 }
 
-
+function debounce(callback, delay) {
+    let timer = null;
+    return (...args) => {
+        clearTimeout(timer);
+        timer = setTimeout(() => {
+            callback.apply(this, [...args]);
+        }, delay)
+    }
+}
 


### PR DESCRIPTION
搜索结果的分数没有被更新是因为函数调用太早，加一个debounce延迟半秒可以稍微解决这个问题，但是如果加载时间超出半秒依然会导致分数不被更新。

也修改了一下监听头的selector，更直观一点点。